### PR TITLE
Refactor category handling and render categories as a list

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
-./forum.db
+# SQLite Database files
+*.db
+
+uploads/

--- a/database/database.go
+++ b/database/database.go
@@ -18,6 +18,7 @@ type Post struct {
 	Content        string
 	Preview        string // Truncated content for preview
 	Category       string
+	CategoryArray  []string // New field to store the category as an array
 	CreatedAt      time.Time
 	UpdatedAt      time.Time
 	Username       string // Add this field to store the post author's username

--- a/database/database.go
+++ b/database/database.go
@@ -486,9 +486,10 @@ func GetAllPosts(category string) ([]Post, error) {
 }
 
 // UpdatePost updates an existing post.
-func UpdatePost(postID int, title, content, category string) error {
+func UpdatePost(postID int, title, content string, category []string) error {
+	categoryStr := strings.Join(category, ",")
 	query := `UPDATE posts SET title = ?, content = ?, category = ?, updated_at = ? WHERE id = ?`
-	_, err := DB.Exec(query, title, content, category, time.Now(), postID)
+	_, err := DB.Exec(query, title, content, categoryStr, time.Now(), postID)
 	return err
 }
 
@@ -596,9 +597,11 @@ func GetReactionCounts(postID int) (int, int, error) {
 }
 
 // CreatePostWithImage creates a new post with an optional image.
-func CreatePostWithImage(userID int, title, content, category, imageURL string) error {
+func CreatePostWithImage(userID int, title, content string, category []string, imageURL string) error {
+	categoryStr := strings.Join(category, ",")
+
 	query := `INSERT INTO posts (user_id, title, content, category, image_url) VALUES (?, ?, ?, ?, ?)`
-	_, err := DB.Exec(query, userID, title, content, category, imageURL)
+	_, err := DB.Exec(query, userID, title, content, categoryStr, imageURL)
 	return err
 }
 

--- a/database/database.go
+++ b/database/database.go
@@ -391,9 +391,9 @@ func GetAllPosts(category string) ([]Post, error) {
 	if category != "" {
 		query := `
 		SELECT p.id, p.user_id, p.title, p.content, p.category, p.image_url, p.created_at, p.updated_at,
-		       IFNULL(likes.count, 0) AS likes, 
-		       IFNULL(dislikes.count, 0) AS dislikes,
-		       IFNULL(comments.count, 0) AS comments_count
+			IFNULL(likes.count, 0) AS likes, 
+			IFNULL(dislikes.count, 0) AS dislikes,
+			IFNULL(comments.count, 0) AS comments_count
 		FROM posts p
 		LEFT JOIN (
 			SELECT post_id, COUNT(*) AS count
@@ -412,10 +412,10 @@ func GetAllPosts(category string) ([]Post, error) {
 			FROM comments
 			GROUP BY post_id
 		) AS comments ON p.id = comments.post_id
-		WHERE p.category = ?
+		WHERE p.category LIKE ?
 		ORDER BY p.created_at DESC`
 
-		rows, err = DB.Query(query, category)
+		rows, err = DB.Query(query, "%"+category+"%")
 	} else {
 		query := `
 		SELECT p.id, p.user_id, p.title, p.content, p.category, p.image_url, p.created_at, p.updated_at,
@@ -504,26 +504,30 @@ func DeletePost(postID int) error {
 // GetCategoryPostCounts retrieves the number of posts for each category.
 func GetCategoryPostCounts() (map[string]int, error) {
 	query := `
-        SELECT category, COUNT(*) as count 
-        FROM posts 
-        GROUP BY category
+        SELECT category 
+        FROM posts
     `
 
 	rows, err := DB.Query(query)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
+    if err != nil {
+        return nil, err
+    }
+    defer rows.Close()
 
-	counts := make(map[string]int)
-	for rows.Next() {
-		var category string
-		var count int
-		if err := rows.Scan(&category, &count); err != nil {
-			return nil, err
-		}
-		counts[category] = count
-	}
+    counts := make(map[string]int)
+    for rows.Next() {
+        var categoryStr string
+        if err := rows.Scan(&categoryStr); err != nil {
+            return nil, err
+        }
+
+        // Split the category string into individual categories
+        categories := strings.Split(categoryStr, ",")
+        for _, category := range categories {
+            category = strings.TrimSpace(category) // Trim any extra spaces
+            counts[category]++
+        }
+    }
 
 	return counts, nil
 }

--- a/handlers/category.go
+++ b/handlers/category.go
@@ -69,7 +69,3 @@ func PostsByCategoryHandler(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
-// GetCategoriesHandler handles fetching all categories
-func GetCategoriesHandler(w http.ResponseWriter, r *http.Request) {
-	// Move categories fetching code here
-}

--- a/handlers/handlers.go
+++ b/handlers/handlers.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"text/template"
+	"strings"
 
 	"forum/database"
 	"forum/utils"
@@ -84,6 +85,7 @@ func HomeHandler(w http.ResponseWriter, r *http.Request) {
 			posts[i].Preview = posts[i].Content
 		}
 		posts[i].CreatedAtHuman = utils.TimeAgo(posts[i].CreatedAt)
+		posts[i].CategoryArray = strings.Split(posts[i].Category, ",")
 	}
 
 	data := map[string]interface{}{
@@ -125,6 +127,7 @@ func DashboardHandler(w http.ResponseWriter, r *http.Request) {
 		} else {
 			posts[i].Username = username
 		}
+		posts[i].CategoryArray = strings.Split(posts[i].Category, ",")
 	}
 
 	// Retrieve category post counts

--- a/handlers/post.go
+++ b/handlers/post.go
@@ -372,7 +372,6 @@ func UserPostHandler(w http.ResponseWriter, r *http.Request) {
 		}
 		posts[i].CreatedAtHuman = utils.TimeAgo(posts[i].CreatedAt)
 		posts[i].CategoryArray = strings.Split(posts[i].Category, ",")
-		fmt.Println(posts[i].CategoryArray)
 	}
 
 	data := map[string]interface{}{

--- a/handlers/post.go
+++ b/handlers/post.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"strconv"
 	"time"
 
@@ -332,10 +333,16 @@ func DislikePostHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 func UserPostHandler(w http.ResponseWriter, r *http.Request) {
-	userID := r.Context().Value(userIDKey).(int)
+	userID, ok := r.Context().Value(userIDKey).(int)
+	if !ok {
+        log.Println("User ID not found in context")
+        RenderErrorPage(w, http.StatusUnauthorized, fmt.Errorf("unauthorized"))
+        return
+    }
+
 	posts, err := database.GetPostsByUserID(userID)
 	if err != nil {
-		RenderErrorPage(w, http.StatusInternalServerError, fmt.Errorf("error retrieving posts: %v", err))
+		RenderErrorPage(w, http.StatusInternalServerError, fmt.Errorf("failed to retrieve posts: %v", err))
 		return
 	}
 
@@ -354,6 +361,7 @@ func UserPostHandler(w http.ResponseWriter, r *http.Request) {
 	if isAuthenticated {
 		username = getUsername(userID)
 	}
+	categoriesArray := make([]string, 0)
 
 	// Add username to posts
 	for i := range posts {
@@ -364,6 +372,7 @@ func UserPostHandler(w http.ResponseWriter, r *http.Request) {
 			posts[i].Preview = posts[i].Content
 		}
 		posts[i].CreatedAtHuman = utils.TimeAgo(posts[i].CreatedAt)
+		categoriesArray = strings.Split(posts[i].Category, ",")
 	}
 
 	data := map[string]interface{}{
@@ -372,6 +381,7 @@ func UserPostHandler(w http.ResponseWriter, r *http.Request) {
 		"Username":        username,
 		"Posts":           posts,
 		"Categories":      categoryCounts,
+		"CategoriesArray": categoriesArray,
 		"IsAuthenticated": isAuthenticated,
 	}
 

--- a/handlers/post.go
+++ b/handlers/post.go
@@ -361,7 +361,6 @@ func UserPostHandler(w http.ResponseWriter, r *http.Request) {
 	if isAuthenticated {
 		username = getUsername(userID)
 	}
-	categoriesArray := make([]string, 0)
 
 	// Add username to posts
 	for i := range posts {
@@ -372,7 +371,8 @@ func UserPostHandler(w http.ResponseWriter, r *http.Request) {
 			posts[i].Preview = posts[i].Content
 		}
 		posts[i].CreatedAtHuman = utils.TimeAgo(posts[i].CreatedAt)
-		categoriesArray = strings.Split(posts[i].Category, ",")
+		posts[i].CategoryArray = strings.Split(posts[i].Category, ",")
+		fmt.Println(posts[i].CategoryArray)
 	}
 
 	data := map[string]interface{}{
@@ -381,7 +381,6 @@ func UserPostHandler(w http.ResponseWriter, r *http.Request) {
 		"Username":        username,
 		"Posts":           posts,
 		"Categories":      categoryCounts,
-		"CategoriesArray": categoriesArray,
 		"IsAuthenticated": isAuthenticated,
 	}
 

--- a/handlers/post.go
+++ b/handlers/post.go
@@ -55,9 +55,9 @@ func CreatePostHandler(w http.ResponseWriter, r *http.Request) {
 
 		title := r.FormValue("title")
 		content := r.FormValue("content")
-		category := r.FormValue("category")
+		category := r.Form["category[]"]
 
-		if title == "" || content == "" || category == "" {
+		if title == "" || content == "" || len(category) == 0 {
 			log.Println("Missing required fields")
 			RenderErrorPage(w, http.StatusBadRequest, fmt.Errorf("title, content, and category are required"))
 			return
@@ -169,7 +169,7 @@ func EditPostHandler(w http.ResponseWriter, r *http.Request) {
 	if r.Method == http.MethodPost {
 		title := r.FormValue("title")
 		content := r.FormValue("content")
-		category := r.FormValue("category")
+		category := r.Form["category[]"]
 
 		err := database.UpdatePost(postID, title, content, category)
 		if err != nil {

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -564,21 +564,9 @@ hr {
     gap: 10px;
 }
 
-/* .category-tag {
-    background: none;
-    padding: 4px;
-    border: 1px solid rgba(211, 211, 211, 0.267);
-    border-radius: 20px;
-}
-
-.category-tag p {
-    font-size: .7rem;
-    color: var(--header-background);
-} */
-
 .category-tag ul {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     padding: 0;
     margin: 0;
     list-style: none;
@@ -588,8 +576,9 @@ hr {
     margin-right: 10px;
     background-color: var(--card-background);
     padding: 5px 10px;
+    border: 1px solid rgba(211, 211, 211, 0.267);
     border-radius: 5px;
-    color: var(--text-color);
+    color: var(--header-background);
     font-family: "poppins", sans-serif;
 }
 

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -577,7 +577,7 @@ hr {
     background-color: var(--card-background);
     padding: 5px 10px;
     border: 1px solid rgba(211, 211, 211, 0.267);
-    border-radius: 5px;
+    border-radius: 20px;
     color: var(--header-background);
     font-family: "poppins", sans-serif;
 }

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -53,7 +53,6 @@ header {
     background: var(--card-background);
 }
 
-
 header.header-container {
     display: flex;
     justify-content: space-between;
@@ -565,7 +564,7 @@ hr {
     gap: 10px;
 }
 
-.category-tag {
+/* .category-tag {
     background: none;
     padding: 4px;
     border: 1px solid rgba(211, 211, 211, 0.267);
@@ -575,6 +574,23 @@ hr {
 .category-tag p {
     font-size: .7rem;
     color: var(--header-background);
+} */
+
+.category-tag ul {
+    display: flex;
+    flex-wrap: wrap;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.category-tag li {
+    margin-right: 10px;
+    background-color: var(--card-background);
+    padding: 5px 10px;
+    border-radius: 5px;
+    color: var(--text-color);
+    font-family: "poppins", sans-serif;
 }
 
 .avatar-name p {

--- a/static/js/categories.js
+++ b/static/js/categories.js
@@ -36,7 +36,9 @@ document.addEventListener('DOMContentLoaded', () => {
                                 </div>
                                 <div class="category-tag-container">
                                     <div class="category-tag">
-                                        <p>${post.Category}</p>
+                                        <ul>
+                                            ${post.Category.split(',').map(cat => `<li><span class="category">${cat.trim()}</span></li>`).join('')}
+                                        </ul>                                        
                                     </div>
                                     ${post.IsOwner ? `
                                         <div class="post-options-menu">

--- a/static/js/mobileMenu.js
+++ b/static/js/mobileMenu.js
@@ -64,7 +64,9 @@ document.addEventListener('DOMContentLoaded', () => {
                                 </div>
                                 <div class="category-tag-container">
                                     <div class="category-tag">
-                                        <p>${post.Category}</p>
+                                        <ul>
+                                            ${post.Category.split(',').map(cat => `<li><span class="category">${cat.trim()}</span></li>`).join('')}
+                                        </ul> 
                                     </div>
                                     ${post.IsOwner ? `
                                         <div class="post-options-menu">

--- a/templates/create-post.html
+++ b/templates/create-post.html
@@ -20,7 +20,7 @@
         <form action="/create-post" method="POST" enctype="multipart/form-data" class="post-form">
             <div class="form-group">
                 <label for="category">Category:</label>
-                <select id="category" name="category" required>
+                <select id="category" name="category[]" multiple required>
                     {{range .Categories}}
                     <option value="{{.}}">{{.}}</option>
                     {{end}}

--- a/templates/create-post.html
+++ b/templates/create-post.html
@@ -20,11 +20,14 @@
         <form action="/create-post" method="POST" enctype="multipart/form-data" class="post-form">
             <div class="form-group">
                 <label for="category">Category:</label>
-                <select id="category" name="category[]" multiple required>
+                <div id="category">
                     {{range .Categories}}
-                    <option value="{{.}}">{{.}}</option>
+                    <div>
+                        <input type="checkbox" id="category-{{.}}" name="category[]" value="{{.}}">
+                        <label for="category-{{.}}">{{.}}</label>
+                    </div>
                     {{end}}
-                </select>
+                </div>
             </div>
             <div class="form-group">
                 <label for="title">Title:</label>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -60,7 +60,11 @@
                 </div>
                 <div class="category-tag-container">
                     <div class="category-tag">
-                        <p>{{.Category}}</p>
+                        <ul>
+                            {{range .CategoryArray}}
+                            <li>{{.}}</li>
+                            {{end}}
+                        </ul>
                     </div>
                     {{if eq .UserID $.UserID}}
                     <div class="post-options-menu">


### PR DESCRIPTION
___

**Description:**
This pull request includes the following changes:
- Updated database queries to handle multiple categories per post.
- Modified `GetAllPosts` function to split and filter categories.
- Adjusted `Post` struct to include `Categories` as a slice of strings.
- Updated JavaScript to render categories as a list.
- Ensured category filtering works with comma-separated values.
- Rendered post categories as a list in the mobile menu.
- Added `.gitignore` entries for SQLite database files and uploads directory.

**Changes:**
1. **Database Changes:**
   - Updated SQL queries to use `LIKE` for category matching.
   - Modified `GetAllPosts` function to handle multiple categories.

2. **Backend Changes:**
   - Adjusted `Post` struct to include `Categories` as a slice of strings.

3. **Frontend Changes:**
   - Updated JavaScript to split category strings and render them as list items.
   - Ensured category filtering works with comma-separated values.
   - Rendered post categories as a list in the mobile menu.

4. **.gitignore Changes:**
   - Added entries for SQLite database files (`*.db`) and uploads directory (`uploads/`).

**Testing:**
- Verified that posts with multiple categories are correctly displayed and filtered.
- Ensured that categories are rendered as list items in the mobile menu.
- Confirmed that `.gitignore` entries are correctly ignoring specified files and directories.
___
